### PR TITLE
Remove Hardcoded Platform in `PYOPENGL_PLATFORM`

### DIFF
--- a/src/body_visualizer/tools/vis_tools.py
+++ b/src/body_visualizer/tools/vis_tools.py
@@ -25,13 +25,12 @@ import numpy as np
 import cv2
 import os
 import trimesh
-# import platform
-# if 'Ubuntu' in platform.version():
-#     print('In Ubuntu, using osmesa mode for rendering')
-#     os.environ['PYOPENGL_PLATFORM'] = 'osmesa'
-# else:
-#     print('In other system, using egl mode for rendering')
-os.environ['PYOPENGL_PLATFORM'] = 'egl'
+
+# Depending on operating system, one may need to set this environment variable, like this:
+#   os.environ['PYOPENGL_PLATFORM'] = 'egl'
+# See related issues that may provide leads to fix it if needed:
+#   https://github.com/mkocabas/VIBE/issues/101
+#   https://github.com/MPI-IS/mesh/issues/49#issuecomment-705194582
 
 
 colors = {

--- a/src/body_visualizer/tools/vis_tools.py
+++ b/src/body_visualizer/tools/vis_tools.py
@@ -178,7 +178,7 @@ def meshes_as_png(meshes, outpath=None, view_angles=[0, 180]):
 
     imw = 800
     imh = 800
-    mv = MeshViewer(imh, imw)
+    mv = MeshViewer(width=imw, height=imh)
     mv.set_cam_trans([0, -.5, 1.75])
     images = np.zeros([len(meshes), len(view_angles), 1, imw, imh, 3])
     for mIdx, mesh in enumerate(meshes):


### PR DESCRIPTION
Hello,

Thank you for your amazing work on this repository! I have been trying to use the visualization tools in `src/body_visualizer/tools/vis_tools.py` and encountered issues with PyOpenGL. The fix was to follow this here: https://github.com/MPI-IS/mesh/issues/66 

When installing this library with pip, `pip install git+https://github.com/nghorbani/body_visualizer`, the code within the file that overwrites the environment variable `PYOPENGL_PLATFORM` to always be `egl` can cause issues. Like in the linked issue, we needed the platform to be set at `osmesa` for our render code to work. 

I've also add the small change in the function `meshes_as_png` in the same file. The change makes no functional difference, but the argument order in the constructor of `MeshViewer` was flipped so that width was height and height was width. This is just so that future readers of this code may save a minute or two figuring out why their images look odd if they change the height and width to other values that are not square. 