### PR TITLE
deleted hard-coded `egl` backend, because e.g. on macOS you need `osmesa`

### DIFF
--- a/src/body_visualizer/tools/vis_tools.py
+++ b/src/body_visualizer/tools/vis_tools.py
@@ -31,7 +31,7 @@ import trimesh
 #     os.environ['PYOPENGL_PLATFORM'] = 'osmesa'
 # else:
 #     print('In other system, using egl mode for rendering')
-os.environ['PYOPENGL_PLATFORM'] = 'egl'
+# os.environ['PYOPENGL_PLATFORM'] = 'egl'
 
 
 colors = {


### PR DESCRIPTION
The user should be able to set the backend and currently it will always be incorrectly overwritten when importing this module